### PR TITLE
feat: add support for ID, Bank, Driver, and Router secure note types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,12 @@ jobs:
         with:
           python-version: '3.11'
       - run: uv run ruff check .
+
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: '3.11'
+      - run: uv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 
 # test data
 C2Password_Export_*.csv
+bitwarden_file.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ dependencies = []
 dev = [
     "pyinstaller>=6.20.0",
     "ruff>=0.15.0",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+]
+test = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
 ]
 
 [tool.uv]
@@ -24,3 +30,9 @@ preview = true
 select = ["E", "W", "F", "B", "UP", "RUF"]
 ignore = ["E501", "UP015", "E712"]
 extend-select = ["TID252"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+addopts = "--verbose --color=yes"
+

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Script to run tests for SynologyC2Password-to-Bitwarden
+
+set -e
+
+echo "=========================================="
+echo "Running tests for SynologyC2Password-to-Bitwarden"
+echo "=========================================="
+
+# Check if pytest is installed
+if ! command -v pytest &> /dev/null; then
+    echo "pytest not found. Installing..."
+    pip install pytest pytest-cov
+fi
+
+# Run tests with coverage
+pytest tests/ -v --cov=syno2bw --cov-report=html --cov-report=term
+
+echo ""
+echo "=========================================="
+echo "Tests completed!"
+echo "Coverage report: htmlcov/index.html"
+echo "=========================================="

--- a/syno2bw.py
+++ b/syno2bw.py
@@ -235,7 +235,7 @@ def build_secure_note(others: dict, name: str, notes: str, favorite: bool, item_
     # For specific types (ID, Bank, Driver, Router), extract all relevant fields
     if item_type in ("id", "bank", "driver", "router"):
         type_specific_notes = []
-        
+
         # Common fields - check for both prefixed and non-prefixed versions
         # The prefix in the JSON is Title Case (Driver, Bank, Router) or all caps (ID)
         prefix = item_type.upper() if item_type == "id" else item_type.title()
@@ -245,7 +245,7 @@ def build_secure_note(others: dict, name: str, notes: str, favorite: bool, item_
         last_name = field(others.get("Last_Name") or others.get(f"{prefix}_Last_Name"))
         if last_name:
             type_specific_notes.append(f"Last Name: {last_name}")
-        
+
         # Type-specific fields
         if item_type == "id":
             if "ID_Number" in others:
@@ -269,7 +269,7 @@ def build_secure_note(others: dict, name: str, notes: str, favorite: bool, item_
                     type_specific_notes.append(f"Address: {field(addr_data.get('Address'))}")
                 if "City_Town" in addr_data:
                     type_specific_notes.append(f"City: {field(addr_data.get('City_Town'))}")
-        
+
         elif item_type == "bank":
             if "Bank_Name" in others:
                 type_specific_notes.append(f"Bank: {field(others.get('Bank_Name'))}")
@@ -283,7 +283,7 @@ def build_secure_note(others: dict, name: str, notes: str, favorite: bool, item_
                 type_specific_notes.append(f"Routing: {field(others.get('Bank_Routing'))}")
             if "Bank_PIN" in others:
                 type_specific_notes.append(f"PIN: {field(others.get('Bank_PIN'))}")
-        
+
         elif item_type == "driver":
             if "Driver_Number" in others:
                 type_specific_notes.append(f"License Number: {field(others.get('Driver_Number'))}")
@@ -299,11 +299,11 @@ def build_secure_note(others: dict, name: str, notes: str, favorite: bool, item_
                 type_specific_notes.append(f"Address: {field(others.get('Driver_Address'))}")
             if "Driver_City_Town" in others:
                 type_specific_notes.append(f"City: {field(others.get('Driver_City_Town'))}")
-        
+
         elif item_type == "router":
             if "Router_Password" in others:
                 type_specific_notes.append(f"Password: {field(others.get('Router_Password'))}")
-        
+
         secure_text = "\n".join(type_specific_notes) if type_specific_notes else secure_text
 
     # the secure note body is the main content.

--- a/syno2bw.py
+++ b/syno2bw.py
@@ -227,10 +227,84 @@ def build_card(row: dict, others: dict, name: str, notes: str, favorite: bool):
     return item
 
 
-def build_secure_note(others: dict, name: str, notes: str, favorite: bool):
+def build_secure_note(others: dict, name: str, notes: str, favorite: bool, item_type: str = ""):
     """Build a bitwarden secure note item from a C2 row and its Others data."""
 
     secure_text = field(others.get("Secure_Note"))
+
+    # For specific types (ID, Bank, Driver, Router), extract all relevant fields
+    if item_type in ("id", "bank", "driver", "router"):
+        type_specific_notes = []
+        
+        # Common fields - check for both prefixed and non-prefixed versions
+        # The prefix in the JSON is Title Case (Driver, Bank, Router) or all caps (ID)
+        prefix = item_type.upper() if item_type == "id" else item_type.title()
+        first_name = field(others.get("First_Name") or others.get(f"{prefix}_First_Name"))
+        if first_name:
+            type_specific_notes.append(f"First Name: {first_name}")
+        last_name = field(others.get("Last_Name") or others.get(f"{prefix}_Last_Name"))
+        if last_name:
+            type_specific_notes.append(f"Last Name: {last_name}")
+        
+        # Type-specific fields
+        if item_type == "id":
+            if "ID_Number" in others:
+                type_specific_notes.append(f"ID Number: {field(others.get('ID_Number'))}")
+            if "ID_Birthday" in others:
+                type_specific_notes.append(f"Birthday: {field(others.get('ID_Birthday'))}")
+            if "ID_Nationality" in others:
+                type_specific_notes.append(f"Nationality: {field(others.get('ID_Nationality'))}")
+            if "ID_Birth_Place" in others:
+                type_specific_notes.append(f"Birth Place: {field(others.get('ID_Birth_Place'))}")
+            if "ID_Issue" in others:
+                type_specific_notes.append(f"Issue Date: {field(others.get('ID_Issue'))}")
+            if "ID_Expiry" in others:
+                type_specific_notes.append(f"Expiry Date: {field(others.get('ID_Expiry'))}")
+            if "ID_Gender" in others:
+                type_specific_notes.append(f"Gender: {field(others.get('ID_Gender'))}")
+            # ID Address can be a nested object
+            addr_data = others.get("ID_Address")
+            if isinstance(addr_data, dict):
+                if "Address" in addr_data:
+                    type_specific_notes.append(f"Address: {field(addr_data.get('Address'))}")
+                if "City_Town" in addr_data:
+                    type_specific_notes.append(f"City: {field(addr_data.get('City_Town'))}")
+        
+        elif item_type == "bank":
+            if "Bank_Name" in others:
+                type_specific_notes.append(f"Bank: {field(others.get('Bank_Name'))}")
+            if "Bank_Account" in others:
+                type_specific_notes.append(f"Account: {field(others.get('Bank_Account'))}")
+            if "Bank_Acc_Type" in others:
+                type_specific_notes.append(f"Account Type: {field(others.get('Bank_Acc_Type'))}")
+            if "Bank_Branch" in others:
+                type_specific_notes.append(f"Branch: {field(others.get('Bank_Branch'))}")
+            if "Bank_Routing" in others:
+                type_specific_notes.append(f"Routing: {field(others.get('Bank_Routing'))}")
+            if "Bank_PIN" in others:
+                type_specific_notes.append(f"PIN: {field(others.get('Bank_PIN'))}")
+        
+        elif item_type == "driver":
+            if "Driver_Number" in others:
+                type_specific_notes.append(f"License Number: {field(others.get('Driver_Number'))}")
+            if "Driver_Birthday" in others:
+                type_specific_notes.append(f"Birthday: {field(others.get('Driver_Birthday'))}")
+            if "Driver_Issue" in others:
+                type_specific_notes.append(f"Issue Date: {field(others.get('Driver_Issue'))}")
+            if "Driver_Expiry" in others:
+                type_specific_notes.append(f"Expiry Date: {field(others.get('Driver_Expiry'))}")
+            if "Driver_Gender" in others:
+                type_specific_notes.append(f"Gender: {field(others.get('Driver_Gender'))}")
+            if "Driver_Address" in others:
+                type_specific_notes.append(f"Address: {field(others.get('Driver_Address'))}")
+            if "Driver_City_Town" in others:
+                type_specific_notes.append(f"City: {field(others.get('Driver_City_Town'))}")
+        
+        elif item_type == "router":
+            if "Router_Password" in others:
+                type_specific_notes.append(f"Password: {field(others.get('Router_Password'))}")
+        
+        secure_text = "\n".join(type_specific_notes) if type_specific_notes else secure_text
 
     # the secure note body is the main content.
     # if the Notes column also has text we keep both joined together.
@@ -271,7 +345,10 @@ def convert(rows: list[dict]):
                     items.append(build_card(row, others, name, notes, favorite))
 
                 case "secure":
-                    items.append(build_secure_note(others, name, notes, favorite))
+                    items.append(build_secure_note(others, name, notes, favorite, item_type))
+
+                case "id" | "bank" | "driver" | "router":
+                    items.append(build_secure_note(others, name, notes, favorite, item_type))
 
                 case _:  # default to login if the type is unknown or missing
                     username = field(row.get("Login_Username"))
@@ -395,10 +472,12 @@ def find_export(folder: str):
 def finish(code: int = 0):
     """Pause so the output stays on screen, then exit."""
 
-    try:
-        input("\nPress Enter to close...")
-    except EOFError:
-        pass
+    # Only pause if we're running interactively (not in tests/CI)
+    if sys.stdin.isatty():
+        try:
+            input("\nPress Enter to close...")
+        except EOFError:
+            pass
 
     sys.exit(code)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for syno2bw

--- a/tests/fixtures/card.csv
+++ b/tests/fixtures/card.csv
@@ -1,0 +1,3 @@
+Display_Name,Notes,Login_Username,Login_Password,Login_URLs,Login_TOTP,Favorite,Others
+"My Card","Bank card",,,,"{}",false,"{{\"Type\":\"card\", \"Card_Number\":\"1234 5678 9012 3456\", \"Card_Name\":\"John Doe\", \"Card_Type\":\"visa\", \"Card_Expiry\":\"12/25\", \"Card_CVV\":\"123\", \"Card_PIN\":\"4567\", \"Card_Phone\":\"+1234567890\", \"Card_URL\":\"https://bank.com\"}}"
+"My Card No Expiry",,"\"\"\",\"\"\",,"{}",false,"{{\"Type\":\"card\", \"Card_Number\":\"1111222233334444\", \"Card_Type\":\"mastercard\"}}"

--- a/tests/fixtures/login.csv
+++ b/tests/fixtures/login.csv
@@ -1,0 +1,4 @@
+Display_Name,Notes,Login_Username,Login_Password,Login_URLs,Login_TOTP,Favorite,Others
+Test Login,"My note",user1,pass1,"https://example.com",,true,{}
+Empty Login,,,,,,"{}"
+Login with TOTP,"2FA test",user2,pass2,"https://test.com",123456,false,{}

--- a/tests/fixtures/new_types.csv
+++ b/tests/fixtures/new_types.csv
@@ -1,0 +1,6 @@
+Display_Name,Notes,Login_Username,Login_Password,Login_URLs,Login_TOTP,Favorite,Others
+"My ID","ID Number 123",,,,,"{}",false,"{{\"Type\":\"id\", \"Secure_Note\":\"National ID: 12345678\"}}"
+"My Bank","Account info",,,,,"{}",false,"{{\"Type\":\"bank\", \"Secure_Note\":\"IBAN: FR76 1234 5678 9012 3456 7890 123\"}}"
+"My Driver","License",,,,,"{}",false,"{{\"Type\":\"driver\", \"Secure_Note\":\"License: ABC123XYZ\"}}"
+"My Router","Admin creds",,,,,"{}",false,"{{\"Type\":\"router\", \"Secure_Note\":\"IP: 192.168.1.1\nUser: admin\nPass: secret\"}}"
+"Mixed Type","Combined",user,pass,"https://router.com",,"{}",false,"{{\"Type\":\"router\", \"Secure_Note\":\"Backup config\"}}"

--- a/tests/fixtures/secure_note.csv
+++ b/tests/fixtures/secure_note.csv
@@ -1,0 +1,3 @@
+Display_Name,Notes,Login_Username,Login_Password,Login_URLs,Login_TOTP,Favorite,Others
+"My Note","Some notes",,,,,"{}",false,"{{\"Type\":\"secure\", \"Secure_Note\":\"This is a secret\"}}"
+"Note with Existing Notes","Existing content",,,,,"{}",true,"{{\"Type\":\"secure\", \"Secure_Note\":\"Additional secret\"}}"

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -8,8 +8,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from syno2bw import (
     build_login, build_card, build_secure_note,
-    LOGIN_TYPE, SECURE_NOTE_TYPE, CARD_TYPE,
-    TEXT_FIELD, HIDDEN_FIELD
+    LOGIN_TYPE, SECURE_NOTE_TYPE, CARD_TYPE
 )
 
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,0 +1,193 @@
+"""
+Tests for Bitwarden item builders.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from syno2bw import (
+    build_login, build_card, build_secure_note,
+    LOGIN_TYPE, SECURE_NOTE_TYPE, CARD_TYPE,
+    TEXT_FIELD, HIDDEN_FIELD
+)
+
+
+class TestBuildLogin:
+    """Tests for build_login function."""
+
+    def test_basic_login(self):
+        row = {
+            "Display_Name": "Test Login",
+            "Notes": "My note",
+            "Login_Username": "user1",
+            "Login_Password": "pass1",
+            "Login_URLs": "https://example.com",
+            "Favorite": "true"
+        }
+        item = build_login(row, "Test Login", "My note", True)
+
+        assert item["type"] == LOGIN_TYPE
+        assert item["name"] == "Test Login"
+        assert item["notes"] == "My note"
+        assert item["favorite"] is True
+        assert item["login"]["username"] == "user1"
+        assert item["login"]["password"] == "pass1"
+        assert len(item["login"]["uris"]) == 1
+        assert item["login"]["uris"][0]["uri"] == "https://example.com"
+
+    def test_login_no_urls(self):
+        row = {
+            "Display_Name": "Test",
+            "Notes": "",
+            "Login_Username": "user",
+            "Login_Password": "pass",
+            "Login_URLs": "",
+            "Favorite": "false"
+        }
+        item = build_login(row, "Test", "", False)
+
+        assert item["type"] == LOGIN_TYPE
+        assert item["login"]["uris"] == []
+
+    def test_login_with_totp(self):
+        row = {
+            "Display_Name": "Test",
+            "Login_Username": "user",
+            "Login_Password": "pass",
+            "Login_TOTP": "123456",
+        }
+        item = build_login(row, "Test", "", False)
+
+        assert item["login"]["totp"] == "123456"
+
+    def test_login_no_credentials(self):
+        row = {
+            "Display_Name": "Test",
+            "Notes": "Just notes",
+            "Login_Username": "",
+            "Login_Password": "",
+            "Login_URLs": "",
+        }
+        item = build_login(row, "Test", "Just notes", False)
+
+        assert item["type"] == LOGIN_TYPE
+        assert item["login"]["username"] is None
+        assert item["login"]["password"] is None
+
+
+class TestBuildCard:
+    """Tests for build_card function."""
+
+    def test_basic_card(self):
+        row = {
+            "Display_Name": "My Card",
+            "Notes": "Bank card",
+        }
+        others = {
+            "Card_Type": "visa",
+            "Card_Number": "1234 5678 9012 3456",
+            "Card_Name": "John Doe",
+            "Card_Expiry": "12/25",
+            "Card_CVV": "123",
+            "Card_PIN": "4567",
+            "Card_Phone": "+1234567890",
+            "Card_URL": "https://bank.com"
+        }
+        item = build_card(row, others, "My Card", "Bank card", False)
+
+        assert item["type"] == CARD_TYPE
+        assert item["name"] == "My Card"
+        assert item["card"]["brand"] == "Visa"
+        assert item["card"]["number"] == "1234567890123456"  # Spaces removed
+        assert item["card"]["expMonth"] == "12"
+        assert item["card"]["expYear"] == "2025"
+        assert item["card"]["code"] == "123"
+
+        # Check custom fields
+        field_names = [f["name"] for f in item["fields"]]
+        assert "Card_PIN" in field_names
+        assert "Card_Phone" in field_names
+        assert "Card_URL" in field_names
+
+    def test_card_unknown_brand(self):
+        row = {"Display_Name": "Test"}
+        others = {
+            "Card_Type": "unknown",
+            "Card_Number": "1234",
+        }
+        item = build_card(row, others, "Test", "", False)
+        assert item["card"]["brand"] == "Other"
+
+    def test_card_no_expiry(self):
+        row = {"Display_Name": "Test"}
+        others = {
+            "Card_Type": "visa",
+            "Card_Number": "1234",
+        }
+        item = build_card(row, others, "Test", "", False)
+        assert item["card"]["expMonth"] is None
+        assert item["card"]["expYear"] is None
+
+    def test_card_bad_expiry_format(self):
+        row = {"Display_Name": "Test"}
+        others = {
+            "Card_Type": "visa",
+            "Card_Number": "1234",
+            "Card_Expiry": "invalid",
+        }
+        item = build_card(row, others, "Test", "", False)
+        # Bad expiry should be in custom fields
+        field_names = [f["name"] for f in item["fields"]]
+        assert "Card_Expiry" in field_names
+
+    def test_card_with_two_digit_year(self):
+        row = {"Display_Name": "Test"}
+        others = {
+            "Card_Type": "visa",
+            "Card_Number": "1234",
+            "Card_Expiry": "05/28",
+        }
+        item = build_card(row, others, "Test", "", False)
+        assert item["card"]["expYear"] == "2028"
+
+
+class TestBuildSecureNote:
+    """Tests for build_secure_note function."""
+
+    def test_secure_note_only(self):
+        others = {"Secure_Note": "This is a secret note"}
+        item = build_secure_note(others, "My Note", "", False)
+
+        assert item["type"] == SECURE_NOTE_TYPE
+        assert item["name"] == "My Note"
+        assert item["secureNote"]["type"] == 0
+        assert "This is a secret note" in item["notes"]
+
+    def test_secure_note_with_notes(self):
+        others = {"Secure_Note": "Secret"}
+        item = build_secure_note(others, "My Note", "Additional notes", False)
+
+        assert "Additional notes" in item["notes"]
+        assert "Secret" in item["notes"]
+
+    def test_secure_note_no_content(self):
+        others = {}
+        item = build_secure_note(others, "My Note", "", False)
+
+        assert item["type"] == SECURE_NOTE_TYPE
+        assert item["notes"] is None
+
+    def test_secure_note_empty_secure_note(self):
+        others = {"Secure_Note": ""}
+        item = build_secure_note(others, "My Note", "Existing notes", False)
+
+        assert item["notes"] == "Existing notes"
+
+    def test_secure_note_multiline(self):
+        others = {"Secure_Note": "Line 1\nLine 2\nLine 3"}
+        item = build_secure_note(others, "My Note", "", False)
+
+        assert "Line 1" in item["notes"]
+        assert "Line 2" in item["notes"]
+        assert "Line 3" in item["notes"]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -41,7 +41,7 @@ class TestConvert:
                 "Others": '{"Type": "card", "Card_Number": "1234"}'
             }
         ]
-        items, skipped = convert(rows)
+        items, _skipped = convert(rows)
         assert len(items) == 1
         assert items[0]["type"] == CARD_TYPE
 
@@ -57,7 +57,7 @@ class TestConvert:
                 "Others": '{"Type": "secure", "Secure_Note": "Secret"}'
             }
         ]
-        items, skipped = convert(rows)
+        items, _skipped = convert(rows)
         assert len(items) == 1
         assert items[0]["type"] == SECURE_NOTE_TYPE
 
@@ -134,7 +134,7 @@ class TestConvert:
                 "Others": '{"Type": "id", "Secure_Note": "123"}'
             },
         ]
-        items, skipped = convert(rows)
+        items, _skipped = convert(rows)
         assert len(items) == 3
         types = {item["type"] for item in items}
         assert LOGIN_TYPE in types
@@ -150,7 +150,7 @@ class TestConvert:
             "Favorite": "true",
             "Others": "{}"
         }]
-        items, skipped = convert(rows)
+        items, _skipped = convert(rows)
         assert items[0]["favorite"] is True
 
     def test_convert_handles_malformed_row(self):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,170 @@
+"""
+Tests for the main convert function and type mapping.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from syno2bw import convert, SECURE_NOTE_TYPE, LOGIN_TYPE, CARD_TYPE
+
+
+class TestConvert:
+    """Tests for convert function."""
+
+    def test_convert_login(self):
+        rows = [
+            {
+                "Display_Name": "Test Login",
+                "Notes": "A login",
+                "Login_Username": "user",
+                "Login_Password": "pass",
+                "Login_URLs": "https://example.com",
+                "Favorite": "true",
+                "Others": "{}"
+            }
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 1
+        assert items[0]["type"] == LOGIN_TYPE
+        assert len(skipped) == 0
+
+    def test_convert_card(self):
+        rows = [
+            {
+                "Display_Name": "My Card",
+                "Notes": "",
+                "Login_Username": "",
+                "Login_Password": "",
+                "Login_URLs": "",
+                "Favorite": "false",
+                "Others": '{"Type": "card", "Card_Number": "1234"}'
+            }
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 1
+        assert items[0]["type"] == CARD_TYPE
+
+    def test_convert_secure_note(self):
+        rows = [
+            {
+                "Display_Name": "My Note",
+                "Notes": "",
+                "Login_Username": "",
+                "Login_Password": "",
+                "Login_URLs": "",
+                "Favorite": "false",
+                "Others": '{"Type": "secure", "Secure_Note": "Secret"}'
+            }
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 1
+        assert items[0]["type"] == SECURE_NOTE_TYPE
+
+    def test_convert_new_types(self):
+        """Test that ID, Bank, Driver, Router are converted to secure notes."""
+        test_cases = [
+            ('{"Type": "id", "Secure_Note": "123"}', "ID"),
+            ('{"Type": "bank", "Secure_Note": "456"}', "Bank"),
+            ('{"Type": "driver", "Secure_Note": "789"}', "Driver"),
+            ('{"Type": "router", "Secure_Note": "000"}', "Router"),
+        ]
+
+        for others_json, display_name in test_cases:
+            rows = [{
+                "Display_Name": display_name,
+                "Notes": "",
+                "Login_Username": "",
+                "Login_Password": "",
+                "Login_URLs": "",
+                "Favorite": "false",
+                "Others": others_json
+            }]
+            items, skipped = convert(rows)
+            assert len(items) == 1, f"Failed for {display_name}"
+            assert items[0]["type"] == SECURE_NOTE_TYPE, f"Wrong type for {display_name}"
+            assert len(skipped) == 0
+
+    def test_convert_unsupported_type(self):
+        """Test that unsupported types are skipped."""
+        rows = [{
+            "Display_Name": "Unknown Type",
+            "Notes": "",
+            "Login_Username": "",
+            "Login_Password": "",
+            "Login_URLs": "",
+            "Favorite": "false",
+            "Others": '{"Type": "unknown_type"}'
+        }]
+        items, skipped = convert(rows)
+        assert len(items) == 0
+        assert len(skipped) == 1
+        assert "unsupported type" in skipped[0][1]
+
+    def test_convert_no_login_info(self):
+        """Test that entries with no login info and no type are skipped."""
+        rows = [{
+            "Display_Name": "Empty Entry",
+            "Notes": "",
+            "Login_Username": "",
+            "Login_Password": "",
+            "Login_URLs": "",
+            "Favorite": "false",
+            "Others": "{}"
+        }]
+        items, skipped = convert(rows)
+        assert len(items) == 0
+        assert len(skipped) == 1
+
+    def test_convert_mixed_types(self):
+        """Test conversion with multiple types in one file."""
+        rows = [
+            {
+                "Display_Name": "Login",
+                "Login_Username": "user",
+                "Login_Password": "pass",
+                "Others": "{}"
+            },
+            {
+                "Display_Name": "Card",
+                "Others": '{"Type": "card", "Card_Number": "1234"}'
+            },
+            {
+                "Display_Name": "ID",
+                "Others": '{"Type": "id", "Secure_Note": "123"}'
+            },
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 3
+        types = {item["type"] for item in items}
+        assert LOGIN_TYPE in types
+        assert CARD_TYPE in types
+        assert SECURE_NOTE_TYPE in types
+
+    def test_convert_preserves_favorite(self):
+        """Test that favorite flag is preserved."""
+        rows = [{
+            "Display_Name": "Favorite",
+            "Login_Username": "user",
+            "Login_Password": "pass",
+            "Favorite": "true",
+            "Others": "{}"
+        }]
+        items, skipped = convert(rows)
+        assert items[0]["favorite"] is True
+
+    def test_convert_handles_malformed_row(self):
+        """Test that malformed rows are skipped gracefully."""
+        rows = [
+            {"Display_Name": "Good", "Login_Username": "user"},
+            {"malformed": "data"},  # Missing required fields
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 1  # Only the good row
+        assert len(skipped) == 1  # The malformed one
+
+    def test_convert_empty_rows(self):
+        """Test with empty input."""
+        items, skipped = convert([])
+        assert len(items) == 0
+        assert len(skipped) == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,188 @@
+"""
+Integration tests for the full conversion pipeline.
+"""
+import json
+import os
+import sys
+import tempfile
+import contextlib
+import io
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from syno2bw import main, convert, save
+
+
+class TestIntegration:
+    """End-to-end tests for the conversion process."""
+
+    def test_full_conversion_login(self, capsys):
+        """Test full conversion of a login CSV."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create input CSV
+            input_csv = os.path.join(tmpdir, "C2Password_Export_test.csv")
+            with open(input_csv, "w") as f:
+                f.write("Display_Name,Notes,Login_Username,Login_Password,Login_URLs,Login_TOTP,Favorite,Others\n")
+                f.write('"Test Login","My note","user","pass","https://example.com",,"true",{}\n')
+
+            # Change to tmpdir and run main
+            original_dir = os.getcwd()
+            original_argv = sys.argv
+            sys.argv = ["syno2bw.py", input_csv]
+            os.chdir(tmpdir)
+
+            try:
+                with contextlib.redirect_stdout(io.StringIO()) as cap_out:
+                    try:
+                        main()
+                    except SystemExit:
+                        pass
+
+                # Check output file exists
+                output_file = os.path.join(tmpdir, "bitwarden_file.json")
+                assert os.path.exists(output_file), "Output file not created"
+
+                # Verify content
+                with open(output_file, "r") as f:
+                    data = json.load(f)
+                    assert "items" in data
+                    assert len(data["items"]) == 1
+                    assert data["items"][0]["type"] == 1  # LOGIN_TYPE
+                    assert data["items"][0]["login"]["username"] == "user"
+                    assert data["items"][0]["login"]["password"] == "pass"
+            finally:
+                sys.argv = original_argv
+                os.chdir(original_dir)
+
+    def test_full_conversion_all_types(self, capsys):
+        """Test full conversion with all supported types."""
+        import csv as csv_module
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_csv = os.path.join(tmpdir, "C2Password_Export_all.csv")
+            with open(input_csv, "w", newline="") as f:
+                writer = csv_module.writer(f)
+                writer.writerow(["Display_Name", "Notes", "Login_Username", "Login_Password", "Login_URLs", "Login_TOTP", "Favorite", "Others"])
+                writer.writerow(["Login", "", "user", "pass", "https://example.com", "", "false", "{}"])
+                writer.writerow(["Card", "", "", "", "", "{}", "false", json.dumps({"Type": "card", "Card_Number": "1234"})])
+                writer.writerow(["Secure", "", "", "", "", "{}", "false", json.dumps({"Type": "secure", "Secure_Note": "note"})])
+                writer.writerow(["ID", "", "", "", "", "{}", "false", json.dumps({"Type": "id", "Secure_Note": "123"})])
+                writer.writerow(["Bank", "", "", "", "", "{}", "false", json.dumps({"Type": "bank", "Secure_Note": "456"})])
+            original_dir = os.getcwd()
+            original_argv = sys.argv
+            sys.argv = ["syno2bw.py", input_csv]
+            os.chdir(tmpdir)
+
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    try:
+                        main()
+                    except SystemExit:
+                        pass
+
+                output_file = os.path.join(tmpdir, "bitwarden_file.json")
+                with open(output_file, "r") as f:
+                    data = json.load(f)
+                    assert len(data["items"]) == 5
+                    types = {item["type"] for item in data["items"]}
+                    assert 1 in types  # Login
+                    assert 3 in types  # Card
+                    assert 2 in types  # Secure Note (for secure, id, bank)
+            finally:
+                sys.argv = original_argv
+                os.chdir(original_dir)
+
+    def test_full_conversion_preserves_structure(self, capsys):
+        """Test that the Bitwarden JSON structure is correct."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_csv = os.path.join(tmpdir, "C2Password_Export.csv")
+            with open(input_csv, "w") as f:
+                f.write("Display_Name,Notes,Login_Username,Login_Password,Login_URLs,Login_TOTP,Favorite,Others\n")
+                f.write('"Test","Note","user","pass","https://test.com",,"true",{}\n')
+
+            original_dir = os.getcwd()
+            original_argv = sys.argv
+            sys.argv = ["syno2bw.py", input_csv]
+            os.chdir(tmpdir)
+
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    try:
+                        main()
+                    except SystemExit:
+                        pass
+
+                output_file = os.path.join(tmpdir, "bitwarden_file.json")
+                with open(output_file, "r") as f:
+                    data = json.load(f)
+
+                    # Check top-level structure
+                    assert "folders" in data
+                    assert "items" in data
+                    assert data["folders"] == []
+
+                    # Check item structure
+                    item = data["items"][0]
+                    assert "id" in item
+                    assert "type" in item
+                    assert "name" in item
+                    assert "notes" in item
+                    assert "favorite" in item
+                    assert "reprompt" in item
+            finally:
+                sys.argv = original_argv
+                os.chdir(original_dir)
+
+    def test_convert_and_save_manually(self):
+        """Test the convert + save pipeline without main()."""
+        rows = [
+            {
+                "Display_Name": "Test Item",
+                "Notes": "A test",
+                "Login_Username": "user",
+                "Login_Password": "pass",
+                "Login_URLs": "https://example.com",
+                "Favorite": "true",
+                "Others": "{}"
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            items, skipped = convert(rows)
+            assert len(items) == 1
+            assert len(skipped) == 0
+
+            output_path = os.path.join(tmpdir, "test_output.json")
+            saved_path = save(items, output_path)
+
+            assert os.path.exists(saved_path)
+            with open(saved_path, "r") as f:
+                data = json.load(f)
+                assert "items" in data
+                assert len(data["items"]) == 1
+
+    def test_new_types_conversion(self):
+        """Test that new types (ID, Bank, Driver, Router) are converted to secure notes."""
+        test_cases = [
+            ("id", "My ID", "National ID: 123"),
+            ("bank", "My Bank", "IBAN: FR76..."),
+            ("driver", "My Driver", "License: ABC123"),
+            ("router", "My Router", "IP: 192.168.1.1"),
+        ]
+
+        for type_name, name, secure_note in test_cases:
+            rows = [{
+                "Display_Name": name,
+                "Notes": "",
+                "Login_Username": "",
+                "Login_Password": "",
+                "Login_URLs": "",
+                "Favorite": "false",
+                "Others": json.dumps({"Type": type_name, "Secure_Note": secure_note})
+            }]
+
+            items, skipped = convert(rows)
+            assert len(items) == 1
+            assert items[0]["type"] == 2  # SECURE_NOTE_TYPE
+            assert items[0]["name"] == name
+            assert secure_note in items[0]["notes"]
+            assert "secureNote" in items[0]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,7 +32,7 @@ class TestIntegration:
             os.chdir(tmpdir)
 
             try:
-                with contextlib.redirect_stdout(io.StringIO()) as cap_out:
+                with contextlib.redirect_stdout(io.StringIO()):
                     try:
                         main()
                     except SystemExit:
@@ -180,7 +180,7 @@ class TestIntegration:
                 "Others": json.dumps({"Type": type_name, "Secure_Note": secure_note})
             }]
 
-            items, skipped = convert(rows)
+            items, _skipped = convert(rows)
             assert len(items) == 1
             assert items[0]["type"] == 2  # SECURE_NOTE_TYPE
             assert items[0]["name"] == name

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,16 +54,16 @@ class TestReadCSV:
         assert "Login_Username" in columns
 
     def test_read_card_csv(self):
-        rows, columns = read_csv("tests/fixtures/card.csv")
+        rows, _columns = read_csv("tests/fixtures/card.csv")
         assert len(rows) == 2
         assert rows[0]["Display_Name"] == "My Card"
 
     def test_read_secure_note_csv(self):
-        rows, columns = read_csv("tests/fixtures/secure_note.csv")
+        rows, _columns = read_csv("tests/fixtures/secure_note.csv")
         assert len(rows) == 2
 
     def test_read_new_types_csv(self):
-        rows, columns = read_csv("tests/fixtures/new_types.csv")
+        rows, _columns = read_csv("tests/fixtures/new_types.csv")
         assert len(rows) == 5
         assert all("Display_Name" in row for row in rows)
 
@@ -71,7 +71,7 @@ class TestReadCSV:
         # Create UTF-16 file
         utf16_file = tmp_path / "utf16.csv"
         utf16_file.write_bytes("Display_Name\nTest\n".encode("utf-16"))
-        rows, columns = read_csv(str(utf16_file))
+        rows, _columns = read_csv(str(utf16_file))
         assert len(rows) == 1
 
     def test_empty_csv(self, tmp_path):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,81 @@
+"""
+Tests for CSV parsing functions.
+"""
+import os
+import pytest
+import sys
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from syno2bw import read_csv, validate_input_file, clean_path
+
+
+class TestCleanPath:
+    """Tests for clean_path function."""
+
+    def test_none_input(self):
+        assert clean_path(None) is None
+
+    def test_empty_string(self):
+        assert clean_path("") is None
+
+    def test_strip_quotes(self):
+        assert clean_path('"/path/to/file"') == "/path/to/file"
+        assert clean_path("'/path/to/file'") == "/path/to/file"
+
+    def test_replace_separators(self):
+        assert clean_path("C:\\Users\\test") == "C:/Users/test"
+        assert clean_path("C:/Users/test") == "C:/Users/test"
+
+
+class TestValidateInputFile:
+    """Tests for validate_input_file function."""
+
+    def test_nonexistent_file(self, tmp_path):
+        assert validate_input_file(str(tmp_path / "nonexistent.csv")) is False
+
+    def test_directory_not_file(self, tmp_path):
+        assert validate_input_file(str(tmp_path)) is False
+
+    def test_valid_file(self, tmp_path):
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("test")
+        assert validate_input_file(str(test_file)) is True
+
+
+class TestReadCSV:
+    """Tests for read_csv function."""
+
+    def test_read_valid_csv(self):
+        rows, columns = read_csv("tests/fixtures/login.csv")
+        assert len(rows) == 3
+        assert "Display_Name" in columns
+        assert "Login_Username" in columns
+
+    def test_read_card_csv(self):
+        rows, columns = read_csv("tests/fixtures/card.csv")
+        assert len(rows) == 2
+        assert rows[0]["Display_Name"] == "My Card"
+
+    def test_read_secure_note_csv(self):
+        rows, columns = read_csv("tests/fixtures/secure_note.csv")
+        assert len(rows) == 2
+
+    def test_read_new_types_csv(self):
+        rows, columns = read_csv("tests/fixtures/new_types.csv")
+        assert len(rows) == 5
+        assert all("Display_Name" in row for row in rows)
+
+    def test_encoding_detection(self, tmp_path):
+        # Create UTF-16 file
+        utf16_file = tmp_path / "utf16.csv"
+        utf16_file.write_bytes("Display_Name\nTest\n".encode("utf-16"))
+        rows, columns = read_csv(str(utf16_file))
+        assert len(rows) == 1
+
+    def test_empty_csv(self, tmp_path):
+        empty_file = tmp_path / "empty.csv"
+        empty_file.write_text("")
+        with pytest.raises(ValueError, match="empty"):
+            read_csv(str(empty_file))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,7 +140,7 @@ class TestParseExpiry:
         assert raw == ""
 
     def test_mm_yyyy(self):
-        month, year, raw = parse_expiry("12/2025")
+        month, year, _raw = parse_expiry("12/2025")
         assert month == "12"
         assert year == "2025"
 
@@ -151,18 +151,18 @@ class TestParseExpiry:
         assert raw == "invalid"
 
     def test_mm_only(self):
-        month, year, raw = parse_expiry("13/25")  # Invalid month
+        month, year, _raw = parse_expiry("13/25")  # Invalid month
         assert month == ""
         assert year == ""
 
     def test_yy_mm_format(self):
         # Should not work (wrong format)
-        month, year, raw = parse_expiry("25/01")
+        month, year, _raw = parse_expiry("25/01")
         assert month == ""
         assert year == ""
 
     def test_with_spaces(self):
-        month, year, raw = parse_expiry(" 01 / 25 ")
+        month, year, _raw = parse_expiry(" 01 / 25 ")
         assert month == "1"
         assert year == "2025"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,193 @@
+"""
+Tests for utility functions.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from syno2bw import (
+    is_value_present, field, build_uris, custom_field,
+    parse_others, parse_expiry, normalize_brand,
+    TEXT_FIELD, HIDDEN_FIELD
+)
+
+
+class TestIsValuePresent:
+    """Tests for is_value_present function."""
+
+    def test_none(self):
+        assert is_value_present(None) is False
+
+    def test_empty_string(self):
+        assert is_value_present("") is False
+
+    def test_whitespace(self):
+        assert is_value_present("   ") is False
+
+    def test_nan(self):
+        assert is_value_present("nan") is False
+        assert is_value_present("NaN") is False
+
+    def test_none_string(self):
+        assert is_value_present("none") is False
+        assert is_value_present("None") is False
+
+    def test_null(self):
+        assert is_value_present("null") is False
+
+    def test_valid_string(self):
+        assert is_value_present("test") is True
+        assert is_value_present("  test  ") is True
+
+
+class TestField:
+    """Tests for field function."""
+
+    def test_none(self):
+        assert field(None) == ""
+
+    def test_empty(self):
+        assert field("") == ""
+
+    def test_whitespace(self):
+        assert field("   ") == ""
+
+    def test_valid(self):
+        assert field("test") == "test"
+
+
+class TestBuildUris:
+    """Tests for build_uris function."""
+
+    def test_none(self):
+        assert build_uris(None) == []
+
+    def test_empty(self):
+        assert build_uris("") == []
+
+    def test_single_url(self):
+        result = build_uris("https://example.com")
+        assert len(result) == 1
+        assert result[0]["uri"] == "https://example.com"
+
+    def test_multiple_urls(self):
+        urls = "https://example.com\nhttps://test.com"
+        result = build_uris(urls)
+        assert len(result) == 2
+
+    def test_urls_with_spaces(self):
+        urls = "https://example.com \n https://test.com"
+        result = build_uris(urls)
+        assert len(result) == 2
+        assert result[0]["uri"] == "https://example.com"
+        assert result[1]["uri"] == "https://test.com"
+
+
+class TestCustomField:
+    """Tests for custom_field function."""
+
+    def test_text_field(self):
+        result = custom_field("test", "value", TEXT_FIELD)
+        assert result["name"] == "test"
+        assert result["value"] == "value"
+        assert result["type"] == TEXT_FIELD
+
+    def test_hidden_field(self):
+        result = custom_field("password", "secret", HIDDEN_FIELD)
+        assert result["type"] == HIDDEN_FIELD
+
+    def test_empty_value(self):
+        result = custom_field("test", "", TEXT_FIELD)
+        assert result["value"] == ""
+
+
+class TestParseOthers:
+    """Tests for parse_others function."""
+
+    def test_none(self):
+        assert parse_others(None) is None
+
+    def test_empty(self):
+        assert parse_others("") is None
+
+    def test_invalid_json(self):
+        assert parse_others("{invalid}") is None
+
+    def test_valid_json(self):
+        result = parse_others('{"Type": "card", "Card_Number": "1234"}')
+        assert result is not None
+        assert result["Type"] == "card"
+        assert result["Card_Number"] == "1234"
+
+    def test_non_dict_json(self):
+        assert parse_others('["array"]') is None
+
+
+class TestParseExpiry:
+    """Tests for parse_expiry function."""
+
+    def test_none(self):
+        assert parse_expiry(None) == ("", "", "")
+
+    def test_empty(self):
+        assert parse_expiry("") == ("", "", "")
+
+    def test_mm_yy(self):
+        month, year, raw = parse_expiry("01/25")
+        assert month == "1"
+        assert year == "2025"
+        assert raw == ""
+
+    def test_mm_yyyy(self):
+        month, year, raw = parse_expiry("12/2025")
+        assert month == "12"
+        assert year == "2025"
+
+    def test_invalid(self):
+        month, year, raw = parse_expiry("invalid")
+        assert month == ""
+        assert year == ""
+        assert raw == "invalid"
+
+    def test_mm_only(self):
+        month, year, raw = parse_expiry("13/25")  # Invalid month
+        assert month == ""
+        assert year == ""
+
+    def test_yy_mm_format(self):
+        # Should not work (wrong format)
+        month, year, raw = parse_expiry("25/01")
+        assert month == ""
+        assert year == ""
+
+    def test_with_spaces(self):
+        month, year, raw = parse_expiry(" 01 / 25 ")
+        assert month == "1"
+        assert year == "2025"
+
+
+class TestNormalizeBrand:
+    """Tests for normalize_brand function."""
+
+    def test_visa(self):
+        assert normalize_brand("visa") == "Visa"
+        assert normalize_brand("VISA") == "Visa"
+
+    def test_mastercard(self):
+        assert normalize_brand("mastercard") == "Mastercard"
+        assert normalize_brand("MasterCard") == "Mastercard"
+
+    def test_amex(self):
+        assert normalize_brand("amex") == "Amex"
+        assert normalize_brand("american express") == "Amex"
+
+    def test_unknown(self):
+        assert normalize_brand("unknown") == "Other"
+        assert normalize_brand("") == ""
+
+    def test_diners_club(self):
+        assert normalize_brand("diners club") == "Diners Club"
+
+    def test_jcb(self):
+        assert normalize_brand("jcb") == "JCB"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,113 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
+    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
@@ -39,6 +146,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -79,6 +204,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -132,7 +287,13 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "pyinstaller" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -140,5 +301,65 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pyinstaller", specifier = ">=6.20.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.15.0" },
+]
+test = [
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]


### PR DESCRIPTION
- Extend `build_secure_note` to handle type-specific fields for ID, Bank, Driver, and Router.
- Add pytest and pytest-cov as dev and test dependencies in pyproject.toml.
- Configure pytest options for test paths, file patterns, and verbose output.
- Update .gitignore to exclude bitwarden_file.json.
- Adjust `finish` function to only pause for user input in interactive mode.