### PR TITLE
Import Others Custom fields as Bitwarden custom fields

### DIFF
--- a/syno2bw.py
+++ b/syno2bw.py
@@ -107,6 +107,49 @@ def custom_field(name: str, value: str | None, field_type: int):
     }
 
 
+def custom_fields(others: dict | None):
+    """Turn the Others "Custom" list into bitwarden custom fields."""
+
+    if not isinstance(others, dict):
+        return []
+
+    entries = others.get("Custom")
+    if not isinstance(entries, list):
+        return []
+
+    fields = []
+    for index, entry in enumerate(entries, 1):
+        if not isinstance(entry, dict):
+            continue
+
+        kind = str(entry.get("Type", "")).strip()
+
+        # each entry keeps its value under a key named after its own type, like
+        # {"Type": "Password", "Password_Title": "API", "Password": "secret"}
+        value = entry.get(kind) if kind else None
+        if value is None:
+            # unknown type, so take the first key that is not one of the metadata keys
+            for key, candidate in entry.items():
+                if key != "Type" and not key.endswith(("_Title", "_Type", "_Selector")):
+                    value = candidate
+                    break
+
+        if not is_value_present(value):
+            continue
+
+        # the title is what the user named the field in C2
+        name = field(entry.get(f"{kind}_Title")).strip() or kind or f"Custom_{index}"
+
+        # synology marks secret values either by the entry type ("Password")
+        # or by the input type it captured from the web form
+        input_type = field(entry.get(f"{kind}_Type")).strip().lower()
+        hidden = kind.lower() == "password" or input_type == "password"
+
+        fields.append(custom_field(name, value, HIDDEN_FIELD if hidden else TEXT_FIELD))
+
+    return fields
+
+
 def parse_expiry(raw: str | None):
     """Pull month and year out of a card expiry like 01/28. Returns (month, year, raw_if_bad)."""
 
@@ -360,37 +403,45 @@ def convert(rows: list[dict]):
             if others is not None:
                 item_type = str(others.get("Type", "")).strip().lower()
 
+            # any item type can carry user defined fields in the Others json
+            extras = custom_fields(others)
+
+            item = None
             match item_type:
                 case "card":
-                    items.append(build_card(row, others, name, notes, favorite))
+                    item = build_card(row, others, name, notes, favorite)
 
                 case "secure":
-                    items.append(build_secure_note(others, name, notes, favorite))
+                    item = build_secure_note(others, name, notes, favorite)
 
                 case "id":
-                    items.append(build_id(others, name, notes, favorite))
+                    item = build_id(others, name, notes, favorite)
 
                 case "bank":
-                    items.append(build_bank(others, name, notes, favorite))
+                    item = build_bank(others, name, notes, favorite)
 
                 case "driver":
-                    items.append(build_driver(others, name, notes, favorite))
+                    item = build_driver(others, name, notes, favorite)
 
                 case "router":
-                    items.append(build_router(others, name, notes, favorite))
+                    item = build_router(others, name, notes, favorite)
 
                 case _:  # default to login if the type is unknown or missing
                     username = field(row.get("Login_Username"))
                     password = field(row.get("Login_Password"))
                     uris = build_uris(row.get("Login_URLs"))
 
-                    if username or password or uris:
-                        items.append(build_login(row, name, notes, favorite))
+                    if username or password or uris or extras:
+                        item = build_login(row, name, notes, favorite)
                     elif others is not None:
                         reason = f"unsupported type '{others.get('Type')}'"
                         skipped.append((name, reason))
                     else:
                         skipped.append((name, "no login info"))
+
+            if item is not None:
+                item["fields"].extend(extras)
+                items.append(item)
 
         except Exception:
             # if one row blows up, skip it instead of crashing the whole run

--- a/syno2bw.py
+++ b/syno2bw.py
@@ -431,7 +431,7 @@ def convert(rows: list[dict]):
                     password = field(row.get("Login_Password"))
                     uris = build_uris(row.get("Login_URLs"))
 
-                    if username or password or uris or extras:
+                    if username or password or uris or (extras and not item_type):
                         item = build_login(row, name, notes, favorite)
                     elif others is not None:
                         reason = f"unsupported type '{others.get('Type')}'"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -168,3 +168,54 @@ class TestConvert:
         items, skipped = convert([])
         assert len(items) == 0
         assert len(skipped) == 0
+
+    def test_convert_login_with_custom_fields(self):
+        others = (
+            '{"Custom": ['
+            '{"Type": "AutofillWeb", "AutofillWeb_Title": "Email", "AutofillWeb_Type": "text",'
+            ' "AutofillWeb": "me@example.com", "AutofillWeb_Selector": "#email"},'
+            '{"Type": "Password", "Password_Title": "API", "Password": "key123"}'
+            ']}'
+        )
+        rows = [
+            {
+                "Display_Name": "themoviedb",
+                "Login_Username": "user",
+                "Login_Password": "pass",
+                "Login_URLs": "https://www.themoviedb.org",
+                "Others": others,
+            }
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 1
+        assert items[0]["type"] == LOGIN_TYPE
+        assert [(f["name"], f["value"], f["type"]) for f in items[0]["fields"]] == [
+            ("Email", "me@example.com", 0),
+            ("API", "key123", 1),
+        ]
+        assert len(skipped) == 0
+
+    def test_convert_custom_fields_only_still_imported(self):
+        """A row with no login info but custom fields should not be skipped."""
+        rows = [
+            {
+                "Display_Name": "Only Custom",
+                "Others": '{"Custom": [{"Type": "Password", "Password_Title": "API", "Password": "k"}]}',
+            }
+        ]
+        items, skipped = convert(rows)
+        assert len(items) == 1
+        assert items[0]["fields"][0]["name"] == "API"
+        assert len(skipped) == 0
+
+    def test_convert_card_keeps_custom_fields(self):
+        rows = [
+            {
+                "Display_Name": "My Card",
+                "Others": '{"Type": "Card", "Card_Number": "4111111111111111",'
+                          ' "Custom": [{"Type": "Text", "Text_Title": "Bank Line", "Text": "info"}]}',
+            }
+        ]
+        items, skipped = convert(rows)
+        assert items[0]["type"] == CARD_TYPE
+        assert items[0]["fields"][-1] == {"name": "Bank Line", "value": "info", "type": 0}

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -216,6 +216,6 @@ class TestConvert:
                           ' "Custom": [{"Type": "Text", "Text_Title": "Bank Line", "Text": "info"}]}',
             }
         ]
-        items, skipped = convert(rows)
+        items, _skipped = convert(rows)
         assert items[0]["type"] == CARD_TYPE
         assert items[0]["fields"][-1] == {"name": "Bank Line", "value": "info", "type": 0}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from syno2bw import (
-    is_value_present, field, build_uris, custom_field,
+    is_value_present, field, build_uris, custom_field, custom_fields,
     parse_others, parse_expiry, normalize_brand,
     TEXT_FIELD, HIDDEN_FIELD
 )
@@ -191,3 +191,60 @@ class TestNormalizeBrand:
 
     def test_jcb(self):
         assert normalize_brand("jcb") == "JCB"
+
+
+class TestCustomFields:
+    """Tests for custom_fields function."""
+
+    def test_none_and_missing(self):
+        assert custom_fields(None) == []
+        assert custom_fields({}) == []
+        assert custom_fields({"Custom": "not a list"}) == []
+
+    def test_autofill_web_text_and_password(self):
+        others = {
+            "Custom": [
+                {
+                    "Type": "AutofillWeb",
+                    "AutofillWeb_Title": "Email",
+                    "AutofillWeb_Type": "text",
+                    "AutofillWeb": "me@example.com",
+                    "AutofillWeb_Selector": "#email",
+                },
+                {
+                    "Type": "AutofillWeb",
+                    "AutofillWeb_Title": "Password Confirm",
+                    "AutofillWeb_Type": "password",
+                    "AutofillWeb": "secret",
+                    "AutofillWeb_Selector": "#password_confirm",
+                },
+            ]
+        }
+        fields = custom_fields(others)
+        assert fields == [
+            {"name": "Email", "value": "me@example.com", "type": TEXT_FIELD},
+            {"name": "Password Confirm", "value": "secret", "type": HIDDEN_FIELD},
+        ]
+
+    def test_password_entry_is_hidden(self):
+        others = {"Custom": [{"Type": "Password", "Password_Title": "API", "Password": "key123"}]}
+        fields = custom_fields(others)
+        assert fields == [{"name": "API", "value": "key123", "type": HIDDEN_FIELD}]
+
+    def test_missing_title_falls_back_to_type(self):
+        others = {"Custom": [{"Type": "Text", "Text": "hello"}]}
+        assert custom_fields(others)[0]["name"] == "Text"
+
+    def test_unknown_type_uses_first_value_key(self):
+        others = {"Custom": [{"Type": "Mystery", "Mystery_Title": "Thing", "Value": "42"}]}
+        assert custom_fields(others) == [{"name": "Thing", "value": "42", "type": TEXT_FIELD}]
+
+    def test_skips_blank_and_non_dict_entries(self):
+        others = {
+            "Custom": [
+                "junk",
+                {"Type": "Password", "Password_Title": "Empty", "Password": ""},
+                {"Type": "Password", "Password_Title": "Kept", "Password": "v"},
+            ]
+        }
+        assert [f["name"] for f in custom_fields(others)] == ["Kept"]


### PR DESCRIPTION
## Problem

Entries whose `Others` column contains a `Custom` array lose all of those fields on import. `parse_others` only ever looked at `Type`, so the `Custom` list was parsed and then silently thrown away — the login imports into Bitwarden with just username/password/URI and no custom fields.

Example row from a C2 export:

```csv
https://www.themoviedb.org/signup,tld-plus-one,user,pass,,themoviedb.org,,,,,"{
  ""Custom"": [
    { ""Type"": ""AutofillWeb"", ""AutofillWeb_Title"": ""Email"", ""AutofillWeb_Type"": ""text"", ""AutofillWeb"": ""me@example.com"", ""AutofillWeb_Selector"": ""#email"" },
    { ""Type"": ""AutofillWeb"", ""AutofillWeb_Title"": ""Password Confirm"", ""AutofillWeb_Type"": ""password"", ""AutofillWeb"": ""secret"", ""AutofillWeb_Selector"": ""#password_confirm"" },
    { ""Type"": ""Password"", ""Password_Title"": ""API"", ""Password"": ""key123"" }
  ]
}"
```

## Fix

New `custom_fields(others)` reads the `Custom` list and turns each entry into a Bitwarden custom field:

- the value comes from the key named after the entry's own `Type` (`AutofillWeb` -> `entry["AutofillWeb"]`, `Password` -> `entry["Password"]`); an unrecognised type falls back to the first key that is not `Type`/`_Title`/`_Type`/`_Selector`
- the field name is `<Type>_Title`, falling back to the type name and then `Custom_N`
- the field is hidden when the entry type is `Password` or its `<Type>_Type` is `password`, otherwise text
- `_Selector` is dropped since Bitwarden has no slot for it, and blank values / non-dict entries are skipped

`convert` now builds the item into a variable and extends `item["fields"]` before appending, so custom fields survive on **every** type (logins, cards and all the secure note variants), not just logins. A row whose only content is custom fields is now imported as a login instead of being skipped as "no login info".

Output for the row above:

```json
[
  { "name": "Email", "value": "me@example.com", "type": 0 },
  { "name": "Password Confirm", "value": "secret", "type": 1 },
  { "name": "API", "value": "key123", "type": 1 }
]
```

## Tests

Added 9 tests (`tests/test_utils.py`, `tests/test_converter.py`) covering the AutofillWeb text/password split, `Password` entries, missing titles, unknown types, blank and malformed entries, custom-fields-only rows, and custom fields on a card. Full suite passes: 89 tests.
